### PR TITLE
Quick fix for setup.py missing a directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     package_data={'networkunit':[
         os.path.join('tests','*.py'),
         os.path.join('models','*.py'),
+        os.path.join('models/backends','*.py'),
         os.path.join('capabilities','*.py'),
         os.path.join('scores','*.py'),
         os.path.join('plots','*.py')],


### PR DESCRIPTION
This is a hot fix for issue #20 

The setup script was missing a directory to include.